### PR TITLE
Fix replaypriority calculation error

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -239,8 +239,8 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight) const
         const CCoins* coins = AccessCoins(txin.prevout.hash);
         assert(coins);
         if (!coins->IsAvailable(txin.prevout.n)) continue;
-        if (coins->nHeight < nHeight) {
-            dResult += coins->vout[txin.prevout.n].nValue * (nHeight-coins->nHeight);
+        if (coins->nHeight <= nHeight) {
+            dResult += (double)(coins->vout[txin.prevout.n].nValue) * (nHeight-coins->nHeight);
         }
     }
     return tx.ComputePriority(dResult);


### PR DESCRIPTION
CCoinsViewCache::GetPriority had an overflow bug that affects the relaypriority calculation.
    Previous arithmetic function:
        dResult += coins->vout[txin.prevout.n].nValue *(nHeight-coins->nHeight);
        the nValue variable type is int64_t, and the int64_t max value is 9223372036854775807
        the dResult will be negative number!
        The AllowFree function will return False, and the high priority transaction with low fee
        will be reject by node with error insufficient priority!

        int64_t convert double also will loss accuracy
        btc core commit id 0efb273